### PR TITLE
Comments about political opinion are offensive

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,7 +32,7 @@ Harassment:
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or politicial opinion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or political opinion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,7 +32,7 @@ Harassment:
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or politicial opinion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate


### PR DESCRIPTION
Legislation in Northern Ireland treats discrimination on grounds of political opinion similarly to the grounds of religion. This change amends the code of conduct to include political opinion and to prioritise neither of these two grounds of discrimination. For a definition of political opinion see for example:  

http://www.equalityni.org/Individuals/I-have-a-problem-with-a-service/Religious-belief-Political-opinion

> ‘Political opinion’ includes support of any Northern Ireland or UK government politics and matters of public policy.  For example:  Treated less favourably because you are or perceived to be nationalist or unionist. However, not all political opinions have the protection of the law. It does not protect political opinions that support or approve of the use of violence for political ends.

or http://www.legislation.gov.uk/nisi/1998/3162/made