### PR TITLE
There should not be promotion of abuse, even if not clearly in an "offensive comment"

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,6 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Promotion of abuse, exclusion or harassment based on the characteristics above
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,7 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to pub/controversy pieces accepting racist, sexist or homophic groups
+* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to publicity-raising or controversy pieces accepting racist, sexist or homophobic groups
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,7 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-* Promotion of abuse, exclusion or harassment based on the characteristics above
+* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to pub/controversy pieces accepting racist, sexist or homophic groups
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate


### PR DESCRIPTION
"Offensive comments" is too vague to call out promoting discrimination (like links or tweets to pub/controversy pieces by racist, sexist or homophic groups), that hide under "free speech". This backs us up in rejecting that kind of content when admins see it's necessary.

Could be in different place in list, but then would need characteristics list copied.