### PR TITLE
Correct en_US spelling to en_GB

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,14 +8,14 @@ The NI Tech and Design Slack (or NI Tech Slack) is a gathering of people working
 
 The current admin is Maurice Kelly (@mo).
 
-We want this to be a fun, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Participants asked to stop any harassing behavior are expected to comply immediately.
+We want this to be a fun, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Participants asked to stop any harassing behaviour are expected to comply immediately.
 
 Confidentiality:
 ----------------
 
 **Please keep what's said in the NI Tech Slack confidential**. Don't repeat or quote things said here without the affirmative consent of the speaker(s). When quoting (with consent), please be careful not to reveal the existence of the NI Tech Slack. Rather, you can refer to the quote as something that was said "in chat" or while you were talking to the quoted member.
 
-**Please be mindful that things you say here may at some point become public**. While we expect members to honor the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
+**Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 
 Logs and Records:
 -----------------
@@ -35,7 +35,7 @@ Harassment includes:
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
-* Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate
+* Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate
 * Simulated physical contact (e.g. textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
 * Threats of violence
 * Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
@@ -55,9 +55,9 @@ We will respect confidentiality requests for the purpose of protecting victims o
 Consequences
 ------------
 
-Participants asked to stop any harassing behavior are expected to comply immediately.
+Participants asked to stop any harassing behaviour are expected to comply immediately.
 
-If a participant engages in harassing behavior, the admins may take any action they deem appropriate, up to and including expulsion from this slack and identifying the participant publicly as someone about whom we've received complaints.
+If a participant engages in harassing behaviour, the admins may take any action they deem appropriate, up to and including expulsion from this slack and identifying the participant publicly as someone about whom we've received complaints.
 
 Credits and License
 --------------------


### PR DESCRIPTION
I'm assuming these are a result of the US origins of this CoC, but
last I checked Northern Ireland prefers 'our' to 'or' in these cases,
so fix it.