### PR TITLE
Clarify confidentiality section

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -13,7 +13,7 @@ We want this to be a fun, pleasant, and harassment-free experience for everyone,
 Confidentiality:
 ----------------
 
-**Please keep what's said in the NI Tech Slack confidential**. Don't repeat or quote things said here without the affirmative consent of the speaker(s). When quoting (with consent), please be careful not to reveal the existence of the NI Tech Slack. Rather, you can refer to the quote as something that was said "in chat" or while you were talking to the quoted member.
+**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
 **Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -15,12 +15,7 @@ Confidentiality:
 
 **Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
-**Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
-
-Logs and Records:
------------------
-
-**Please be mindful that things you say here may at some point become public**. We cannot prevent people from screencapping or otherwise logging this slack. We also can't guarantee that every member's login credentials and logged-in devices are secure. Files uploaded here can be downloaded by anyone with a login. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
+**Please be mindful that things you say here may at some point become public**. Notwithstanding the above, we cannot guarantee that messages posted will not be seen be non-members, nor by people who become members in the future. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 
 Message Retention:
 ------------------


### PR DESCRIPTION
I've made a couple of changes to Confidentiality section:

- removed the silly bit about "not mentioning the NI Tech Slack in public". AKA the "Fight Club Clause"
- expressed what I feel members deserve with regard to confidentiality. It has to be up to the member if their words can be republished in an open Internet capacity.

(This addresses Issue #13 by @becca1993)