### PR TITLE
Emphasise privacy aspect of private channels/DMs

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -19,7 +19,7 @@ We want this to be a fun, pleasant, and harassment-free experience for everyone,
 Confidentiality:
 ----------------
 
-**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval. Please don't repeat or quote things said here without the affirmative consent of the member(s).
+**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval, especially those messages posted in private channels or direct messages. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
 **Please be mindful that things you say here may at some point become public**. Notwithstanding the above, we cannot guarantee that messages posted will not be seen be non-members, nor by people who become members in the future. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 


### PR DESCRIPTION
This addresses issue #4 (to an extent).

The original feedback on the Code of Conduct wanted to differentiate between things said in private channels/DMs and things said in public channels. I think the Confidentiality section has become more refined since the feedback was original received so I've not gone quite that far, but I have given a little bit more emphasis to the expectation of privacy in private channels/DMs.