### PR TITLE
Refine the "publicly naming" language.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -53,14 +53,14 @@ Reporting
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the admins. They'll respond as promptly as they can. Where possible, take screenshots as evidence of harassment and provide these to the admins.
 
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them. We will not name harassment victims without their affirmative consent.
+We will respect confidentiality requests for the purpose of protecting victims of abuse.
 
 Consequences
 ------------
 
 Participants asked to stop any harassing behaviour are expected to comply immediately.
 
-If a participant engages in harassing behaviour, the admins may take any action they deem appropriate, up to and including expulsion from this slack and identifying the participant publicly as someone about whom we've received complaints.
+If a participant engages in harassing behaviour, the admins may take any action they deem appropriate, up to and including expulsion from this Slack. At our discretion, we may publicly name a person within the Slack about whom we have taken action, or privately warn third parties about them.
 
 Credits and License
 --------------------


### PR DESCRIPTION
This addresses issue #6 

I've removed the "publicly naming" bits from the "Reporting" section. In retrospect, I think we shouldn't be naming parties based solely on reports. I've mostly moved it to the consequences section - it's fair for us to be able to name someone once action has been taken where we see fit.

I've also narrowed the "public" aspect to the Slack. I think that's within our capacity as admins of this Slack - where it goes beyond that is the scope of the harassed party (legal action for example), or how people use the information.