### PR TITLE
Update Confidentiality Clauses to un-protect corporate speech

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -25,9 +25,11 @@ This code of conduct applies to the entire Slack, including private channels and
 Confidentiality
 ---------------
 
-**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval, especially those messages posted in private channels or direct messages. Please don't repeat or quote things said here without the affirmative consent of the member(s).
+**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all individuals who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval, especially those messages posted in private channels or direct messages. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
 **Please be mindful that things you say here may at some point become public**. Notwithstanding the above, we cannot guarantee that messages posted will not be seen be non-members, nor by people who become members in the future. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
+
+**This confidentiality clause may be waived in the case of the community interest (i.e. the reporting of other contraventions of this Code), or in cases where the content posted is in service to the promotion or representation of an outside entity, such as job postings or corporate promotions)**
 
 Message Retention
 -----------------

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -29,7 +29,7 @@ Confidentiality
 
 **Please be mindful that things you say here may at some point become public**. Notwithstanding the above, we cannot guarantee that messages posted will not be seen be non-members, nor by people who become members in the future. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 
-**This confidentiality clause may be waived in the case of the community interest (i.e. the reporting of other contraventions of this Code), or in cases where the content posted is in service to the promotion or representation of an outside entity, such as job postings or corporate promotions)**
+**This confidentiality clause may be waived in the case of the community interest (i.e. the reporting of other contraventions of this Code), or in cases where the content posted is in service to the promotion or representation of an outside entity, such as job postings or corporate promotions**
 
 Message Retention
 -----------------


### PR DESCRIPTION
The intent of the confidentiality clause was to protect the speech of individuals and support a safe environment where by unintended or thoughtless statements taken out of context could be damaging or hurtful.

This is a laudable aim, however I don't believe this protection should extend to corporate speech.

Individuals may choose to take on responsibility from their employers to represent them in this community forum but when speaking as that employer or in service to that employer, those comments and statements should not be protected in the same sense of an individual.

This is not to suggest that *any* speech by an individual should be attributed to their employer; this extended clause is specifically referencing the _content_ of corporate-speech postings, not the accounts or members associated with that content.